### PR TITLE
Add a option to make deprecated input args visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ graphql-schema-diff --help
     --left-schema-header         Header to send to left remote schema source
     --right-schema-header        Header to send to right remote schema source
     --sort-schema, -s            Sort schemas prior to diffing
+    --input-value-deprecation    Include deprecated input value fields   
 
   Examples
     $ graphql-schema-diff https://example.com/graphql schema.graphql

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ graphql-schema-diff --help
     --left-schema-header         Header to send to left remote schema source
     --right-schema-header        Header to send to right remote schema source
     --sort-schema, -s            Sort schemas prior to diffing
-    --input-value-deprecation    Include deprecated input value fields   
+    --input-value-deprecation    Include deprecated input value fields when loading from URL
 
   Examples
     $ graphql-schema-diff https://example.com/graphql schema.graphql

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -19,7 +19,7 @@
         "diff2html": "^3.4.35",
         "disparity": "^3.2.0",
         "fs-extra": "^11.1.1",
-        "graphql": "^16.7.1",
+        "graphql": "^16.8.1",
         "meow": "^9.0.0",
         "node-fetch": "^2.6.11"
       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "diff2html": "^3.4.35",
     "disparity": "^3.2.0",
     "fs-extra": "^11.1.1",
-    "graphql": "^16.7.1",
+    "graphql": "^16.8.1",
     "meow": "^9.0.0",
     "node-fetch": "^2.6.11"
   },

--- a/src/__tests__/fixtures/localSchemaInputValueDeprecated.graphql
+++ b/src/__tests__/fixtures/localSchemaInputValueDeprecated.graphql
@@ -1,0 +1,6 @@
+type Query {
+  field1(
+    testInput1: String
+    testInput2: Float @deprecated(reason: "test2 is deprecated")
+  ): String
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ const cli = meow(
     --left-schema-header \t Header to send to left remote schema source
     --right-schema-header \t Header to send to right remote schema source
     --sort-schema, -s \t\t Sort schemas prior to diffing
-    --input-value-deprecation \t Include deprecated input value fields
+    --input-value-deprecation \t Include deprecated input value fields when loading from URL
 
   Examples
     $ graphql-schema-diff https://example.com/graphql schema.graphql

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ const cli = meow(
     --left-schema-header \t Header to send to left remote schema source
     --right-schema-header \t Header to send to right remote schema source
     --sort-schema, -s \t\t Sort schemas prior to diffing
+    --input-value-deprecation \t Include deprecated input value fields
 
   Examples
     $ graphql-schema-diff https://example.com/graphql schema.graphql
@@ -66,6 +67,9 @@ const cli = meow(
       },
       version: {
         alias: "v",
+      },
+      inputValueDeprecation: {
+        type: "boolean",
       },
     },
   },
@@ -124,6 +128,7 @@ getDiff(leftSchemaLocation, rightSchemaLocation, {
     headers: parseHeaders(rightSchemaHeader),
   },
   sortSchema: cli.flags.sortSchema as boolean,
+  inputValueDeprecation: cli.flags.inputValueDeprecation as boolean,
 })
   .then(async (result) => {
     if (result === undefined) {

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -6,7 +6,7 @@ import {
 } from "graphql";
 import { lexicographicSortSchema } from "graphql/utilities";
 import disparity from "disparity";
-import { loadSchema } from "@graphql-tools/load";
+import { LoadSchemaOptions, loadSchema } from "@graphql-tools/load";
 import { UrlLoader } from "@graphql-tools/url-loader";
 import { JsonFileLoader } from "@graphql-tools/json-file-loader";
 import { printSchemaWithDirectives } from "@graphql-tools/utils";
@@ -31,6 +31,7 @@ export interface DiffOptions {
   };
   headers?: Headers;
   sortSchema?: boolean;
+  inputValueDeprecation?: boolean;
 }
 
 export async function getDiff(
@@ -38,11 +39,14 @@ export async function getDiff(
   rightSchemaLocation: string,
   options: DiffOptions = {},
 ): Promise<DiffResponse | undefined> {
-  const getSchemaOptions = (customHeaders?: Headers) => ({
+  const getSchemaOptions: (
+    customHeaders?: Headers,
+  ) => Omit<LoadSchemaOptions, "loaders"> = (customHeaders) => ({
     headers: { ...options.headers, ...customHeaders },
     skipGraphQLImport: false,
     descriptions: false,
     customFetch: fetch,
+    inputValueDeprecation: options.inputValueDeprecation,
   });
   const leftSchemaOptions = getSchemaOptions(options.leftSchema?.headers);
   const rightSchemaOptions = getSchemaOptions(options.rightSchema?.headers);


### PR DESCRIPTION
This caught us out, as when we removed a deprecated input arg is wasn't as visible as we'd have liked.

By adding this option, we can have visibility of deprecated input args.

---

~Opening as draft, as I think one of my colleagues wants to check it for themselves.~ ✅